### PR TITLE
Added listring/clickshift

### DIFF
--- a/bags/init.lua
+++ b/bags/init.lua
@@ -33,6 +33,8 @@ local get_formspec = function(player,page)
 				.."button[2,0;2,0.5;bags;Bags]"
 				.."image[7,0;1,1;"..image.."]"
 				.."list[current_player;bag"..i.."contents;0,1;8,3;]"
+				.."listring[current_name;bag"..i.."contents]"
+				.."listring[current_player;main]"
 		end
 	end
 end


### PR DESCRIPTION
est31 fixed a bug in the engine that allows listring/shift click to work properly now. This will only work right in the lasted github version. It was fixed a few hours ago.
