### PR TITLE
Create a proper sfinv page and remove the dependency to sfinv_buttons

### DIFF
--- a/bags/depends.txt
+++ b/bags/depends.txt
@@ -1,3 +1,3 @@
 default
 inventory_plus?
-sfinv_buttons?
+sfinv?

--- a/bags/init.lua
+++ b/bags/init.lua
@@ -10,90 +10,14 @@ License: BSD-3-Clause https://raw.github.com/cornernote/minetest-bags/master/LIC
 
 
 local use_sfinv = false
-if not core.global_exists("inventory_plus") and core.global_exists("sfinv_buttons") then
+if not core.global_exists("inventory_plus") and core.global_exists("sfinv") then
 	use_sfinv = true
 else
-	local use_sfinv = (core.global_exists("sfinv_buttons") and core.settings:get("inventory") == "sfinv") or false
-end
-
-
--- get_formspec
-local get_formspec = function(player,page)
-	if page=="bags" then
-		return "size[8,7.5]"
-			.."list[current_player;main;0,3.5;8,4;]"
-			.."button[0,0;2,0.5;main;Back]"
-			.."button[0,2;2,0.5;bag1;Bag 1]"
-			.."button[2,2;2,0.5;bag2;Bag 2]"
-			.."button[4,2;2,0.5;bag3;Bag 3]"
-			.."button[6,2;2,0.5;bag4;Bag 4]"
-			.."list[detached:"..player:get_player_name().."_bags;bag1;0.5,1;1,1;]"
-			.."list[detached:"..player:get_player_name().."_bags;bag2;2.5,1;1,1;]"
-			.."list[detached:"..player:get_player_name().."_bags;bag3;4.5,1;1,1;]"
-			.."list[detached:"..player:get_player_name().."_bags;bag4;6.5,1;1,1;]"
-	end
-	for i=1,4 do
-		if page=="bag"..i then
-			local image = player:get_inventory():get_stack("bag"..i, 1):get_definition().inventory_image
-			return "size[8,8.5]"
-				.."list[current_player;main;0,4.5;8,4;]"
-				.."button[0,0;2,0.5;main;Main]"
-				.."button[2,0;2,0.5;bags;Bags]"
-				.."image[7,0;1,1;"..image.."]"
-				.."list[current_player;bag"..i.."contents;0,1;8,3;]"
-				.."listring[current_name;bag"..i.."contents]"
-				.."listring[current_player;main]"
-		end
-	end
-end
-
--- register_on_player_receive_fields
-minetest.register_on_player_receive_fields(function(player, formname, fields)
-	if use_sfinv then
-		if fields.main then
-			return sfinv.set_page(player, "sfinv_buttons:buttons")
-		elseif fields.bags then
-			player:set_inventory_formspec(get_formspec(player, "bags"))
-			return
-		end
-	elseif fields.bags then
-		inventory_plus.set_inventory_formspec(player, get_formspec(player,"bags"))
-		return
-	end
-	
-	for i=1,4 do
-		local page = "bag"..i
-		if fields[page] then
-			if player:get_inventory():get_stack(page, 1):get_definition().groups.bagslots==nil then
-				page = "bags"
-			end
-			
-			if use_sfinv then
-				player:set_inventory_formspec(get_formspec(player, page))
-			else
-				inventory_plus.set_inventory_formspec(player, get_formspec(player,page))
-			end
-			return
-		end
-	end
-end)
-
-if use_sfinv then
-	sfinv_buttons.register_button("bags", {
-		title = "Bags",
-		action = function(player)
-			player:set_inventory_formspec(get_formspec(player, "bags"))
-		end,
-		image = "bags_small.png",
-	})
+	local use_sfinv = (core.global_exists("sfinv") and core.settings:get("inventory") == "sfinv") or false
 end
 
 -- register_on_joinplayer
 minetest.register_on_joinplayer(function(player)
-	if not use_sfinv then
-		inventory_plus.register_button(player,"bags","Bags")
-	end
-	
 	local player_inv = player:get_inventory()
 	local bags_inv = minetest.create_detached_inventory(player:get_player_name().."_bags",{
 		on_put = function(inv, listname, index, stack, player)
@@ -170,6 +94,11 @@ minetest.register_craft({
         {"bags:medium", "bags:medium"},
     },
 })
+if use_sfinv then
+	dofile(minetest.get_modpath(minetest.get_current_modname()) .. "/sfinv.lua")
+else
+	dofile(minetest.get_modpath(minetest.get_current_modname()) .. "/inventory_plus.lua")
+end
 
 -- log that we started
 minetest.log("action", "[MOD]"..minetest.get_current_modname().." -- loaded from "..minetest.get_modpath(minetest.get_current_modname()))

--- a/bags/inventory_plus.lua
+++ b/bags/inventory_plus.lua
@@ -1,0 +1,55 @@
+-- get_formspec
+local get_formspec = function(player,page)
+	if page=="bags" then
+		return "size[8,7.5]"
+			.."list[current_player;main;0,3.5;8,4;]"
+			.."button[0,0;2,0.5;main;Back]"
+			.."button[0,2;2,0.5;bag1;Bag 1]"
+			.."button[2,2;2,0.5;bag2;Bag 2]"
+			.."button[4,2;2,0.5;bag3;Bag 3]"
+			.."button[6,2;2,0.5;bag4;Bag 4]"
+			.."list[detached:"..player:get_player_name().."_bags;bag1;0.5,1;1,1;]"
+			.."list[detached:"..player:get_player_name().."_bags;bag2;2.5,1;1,1;]"
+			.."list[detached:"..player:get_player_name().."_bags;bag3;4.5,1;1,1;]"
+			.."list[detached:"..player:get_player_name().."_bags;bag4;6.5,1;1,1;]"
+	end
+	for i=1,4 do
+		if page=="bag"..i then
+			local image = player:get_inventory():get_stack("bag"..i, 1):get_definition().inventory_image
+			return "size[8,8.5]"
+				.."list[current_player;main;0,4.5;8,4;]"
+				.."button[0,0;2,0.5;main;Main]"
+				.."button[2,0;2,0.5;bags;Bags]"
+				.."image[7,0;1,1;"..image.."]"
+				.."list[current_player;bag"..i.."contents;0,1;8,3;]"
+				.."listring[current_name;bag"..i.."contents]"
+				.."listring[current_player;main]"
+		end
+	end
+end
+
+-- register_on_player_receive_fields
+minetest.register_on_player_receive_fields(function(player, formname, fields)
+	if fields.bags then
+		inventory_plus.set_inventory_formspec(player, get_formspec(player,"bags"))
+		return
+	end
+
+	for i=1,4 do
+		local page = "bag"..i
+		if fields[page] then
+			if player:get_inventory():get_stack(page, 1):get_definition().groups.bagslots==nil then
+				page = "bags"
+			end
+
+			inventory_plus.set_inventory_formspec(player, get_formspec(player,page))
+			return
+		end
+	end
+end)
+
+-- register_on_joinplayer
+minetest.register_on_joinplayer(function(player)
+	inventory_plus.register_button(player,"bags","Bags")
+end)
+

--- a/bags/sfinv.lua
+++ b/bags/sfinv.lua
@@ -1,0 +1,51 @@
+sfinv.register_page("bags:bags", {
+	title = "Bags",
+	get = function(self, player, context)
+		local bags_inv = ""
+		if context.bags_page == nil or context.bags_page == "bags" then
+			bags_inv = "button[0,2;2,0.5;bag1;Bag 1]"
+					 .."button[2,2;2,0.5;bag2;Bag 2]"
+					 .."button[4,2;2,0.5;bag3;Bag 3]"
+					 .."button[6,2;2,0.5;bag4;Bag 4]"
+					 .."list[detached:"..player:get_player_name().."_bags;bag1;0.5,1;1,1;]"
+					 .."list[detached:"..player:get_player_name().."_bags;bag2;2.5,1;1,1;]"
+					 .."list[detached:"..player:get_player_name().."_bags;bag3;4.5,1;1,1;]"
+					 .."list[detached:"..player:get_player_name().."_bags;bag4;6.5,1;1,1;]"
+		else
+			for i=1,4 do
+				if context.bags_page=="bag"..i then
+					local image = player:get_inventory():get_stack("bag"..i, 1):get_definition().inventory_image
+					bags_inv = "button[2,0;2,0.5;bags_return;Return]"
+						.."image[7,0;1,1;"..image.."]"
+						.."list[current_player;bag"..i.."contents;0,1;8,3;]"
+						.."listring[current_name;bag"..i.."contents]"
+						.."listring[current_player;main]"
+				end
+			end
+		end
+
+		local formspec = sfinv.make_formspec(player, context, bags_inv, true)
+		return formspec
+	end,
+	on_player_receive_fields = function(self, player, context, fields)
+		if fields.bags_return then
+			context.bags_page = "bags"
+			sfinv.set_player_inventory_formspec(player)
+			return true
+		end
+
+		for i=1,4 do
+			local page = "bag"..i
+			if fields[page] then
+				if player:get_inventory():get_stack(page, 1):get_definition().groups.bagslots==nil then
+					context.bags_page = "bags"
+				else
+					context.bags_page = page
+				end
+				sfinv.set_player_inventory_formspec(player)
+				return true
+			end
+		end
+		return false
+	end
+})


### PR DESCRIPTION
This way, the bags look better integrated in the default inventory and it is easier to use, since you don't need an additional dependency (sfinv is in the default game).

This PR also seperates the inventory logic into different files to keep the code more tidy.